### PR TITLE
Add type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
 	"description": "A library which provides extended functionality to WordPress custom post types, allowing developers to quickly build custom post types without having to write the same code again and again.",
 	"homepage"   : "https://github.com/johnbillion/extended-cpts/",
 	"license"    : "GPL-2.0+",
+	"type"       : "wordpress-library",
 	"authors"    : [
 		{
 			"name"    : "John Blackbourn",


### PR DESCRIPTION
Re-adding the type to the composer file will allow us to use the `installer-paths` extra in our project composer file, then we can move the library back into mu-plugins where we've got an autoloader set up.

The alternative would be to add an `autoload` field so composer handles the autoloading for us, like all of our other external dependencies (https://github.com/johnbillion/extended-cpts/pull/36).

P.s. This also applies to extended-taxos, so a similar approach would have to be taken for that as well.
