### PR TITLE
Make autoloadable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
 		"johnbillion/wp-docs-standards": "*",
 		"phpunit/phpunit": ">=3.7"
 	},
+	"autoload": {
+		"classmap": ["extended-cpts.php"]
+	},
 	"suggest": {
 		"johnbillion/extended-taxos": "Extended Taxonomies",
 		"wpackagist-plugin/rewrite-testing": "Rewrite Rule Testing"

--- a/extended-cpts.php
+++ b/extended-cpts.php
@@ -781,6 +781,15 @@ class Extended_CPT {
 		return get_taxonomy( $taxonomy );
 
 	}
+	
+	/**
+	 * Initialize the library and load global functions
+	 */ 
+	public static function init() {
+		
+		// load the library
+		
+	}
 
 }
 }


### PR DESCRIPTION
This PR addresses issue #35 by setting up simple `classmap` autoloading for the library.

[Classmap](https://getcomposer.org/doc/04-schema.md#classmap) autoloading is less problematic than `files` can be, as it is a deferred/lazy loading method.

I also added an `init` method to `Extended_CPT` to use for autoloading the library files.  This currently does nothing (other than triggering the autoloading) as the entire library is contained within the one file.  However, this provides a future-proof way to remain compatible should the library become separated into more files, where the global functions would no longer be autoloadable.  This is a place where a one-time  loading of those files could be done. The only requirement would be for the `Extended_CPT` class to remain autoloadable, but that's the whole point here anyways!  The `init` method is only intended for autoloading right now, but it could eventually be used internally by the library itself to load it's own files should it ever grow to more than the single file it is now.

Again, this really only applies to us folks who are pulling in the library as a Composer dependency.  There's really no reason not to implement autoloading.  The `init` method currently does nothing so it isn't required at all for users who are already using the library in a more conventional way. 
