### PR TITLE
Add $wp_query->the_post(); to fix duplicate/wrong p2p admin columns

### DIFF
--- a/extended-cpts.php
+++ b/extended-cpts.php
@@ -1,4 +1,16 @@
 <?php
+/*
+Plugin Name:  Extended CPTs
+Description:  Extended custom post types.
+Version:      3.0.1
+Plugin URI:   https://github.com/johnbillion/extended-cpts
+Author:       John Blackbourn
+Author URI:   https://johnblackbourn.com
+Text Domain:  extended-cpts
+Domain Path:  /languages/
+License:      GPL v2 or later
+*/
+
 /**
  * Extended custom post types for WordPress.
  *
@@ -1854,6 +1866,7 @@ class Extended_CPT_Admin {
 		if ( ! isset( $_post->$field ) ) {
 			if ( $type = p2p_type( $connection ) ) {
 				$type->each_connected( $wp_query, $meta, $field );
+				$wp_query->the_post();
 			} else {
 				echo esc_html( sprintf(
 					__( 'Invalid connection type: %s', 'extended-cpts' ),

--- a/extended-cpts.php
+++ b/extended-cpts.php
@@ -1,16 +1,4 @@
 <?php
-/*
-Plugin Name:  Extended CPTs
-Description:  Extended custom post types.
-Version:      3.0.1
-Plugin URI:   https://github.com/johnbillion/extended-cpts
-Author:       John Blackbourn
-Author URI:   https://johnblackbourn.com
-Text Domain:  extended-cpts
-Domain Path:  /languages/
-License:      GPL v2 or later
-*/
-
 /**
  * Extended custom post types for WordPress.
  *


### PR DESCRIPTION
I found the same issue as JiveDig (https://github.com/johnbillion/extended-cpts/issues/48) with p2p admin columns.
However, I also found a fix (don't know if it is the most perfect fix). The query had to be assigned the_post() function, so the title in admin column will be populated correctly.
