### PR TITLE
Support date_format within admin_filters

### DIFF
--- a/extended-cpts.php
+++ b/extended-cpts.php
@@ -1092,6 +1092,10 @@ class Extended_CPT_Admin {
 					}
 				}
 
+				if ( isset( $filter['date_format'] ) && true === $filter['date_format'] ) {
+					$filter['date_format'] = get_option( 'date_format' );
+				}
+
 				# Output the dropdown:
 				?>
 				<select name="<?php echo esc_attr( $filter_key ); ?>" id="filter_<?php echo esc_attr( $filter_key ); ?>">
@@ -1099,6 +1103,9 @@ class Extended_CPT_Admin {
 					<?php
 						foreach ( $filter['options'] as $k => $v ) {
 							$key = ( $use_key ? $k : $v );
+							if( !empty( $filter[ 'date_format' ] ) ){
+								$v = date_i18n( $filter[ 'date_format' ], $v );
+							}
 						?>
 						<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $selected, $key ); ?>><?php echo esc_html( $v ); ?></option>
 					<?php } ?>

--- a/extended-cpts.php
+++ b/extended-cpts.php
@@ -1268,7 +1268,10 @@ class Extended_CPT_Admin {
 		$num   = number_format_i18n( $count->publish );
 
 		# This is absolutely not localisable. WordPress 3.8 didn't add a new post type label.
-		$text = '<a href="edit.php?post_type=' . esc_attr( $this->cpt->post_type ) . '">' . esc_html( $num . ' ' . $text ) . '</a>';
+		$url = add_query_arg( [
+			'post_type' => $this->cpt->post_type,
+		], admin_url( 'edit.php' ) );
+		$text = '<a href="' . esc_url( $url ) . '">' . esc_html( $num . ' ' . $text ) . '</a>';
 
 		# Go!
 		$items[] = $text;


### PR DESCRIPTION
Super basic implementation of supporting date_format within admin filters. 
Used when you have a timestamp stored as your meta value and you want a date displayed in the dropdown.
