### PR TITLE
Fix bug with p2p admin columns

### DIFF
--- a/extended-cpts.php
+++ b/extended-cpts.php
@@ -1853,7 +1853,7 @@ class Extended_CPT_Admin {
 
 		if ( ! isset( $_post->$field ) ) {
 			if ( $type = p2p_type( $connection ) ) {
-				$type->each_connected( $wp_query, $meta, $field );
+				$type->each_connected( array( $_post ), $meta, $field );
 			} else {
 				echo esc_html( sprintf(
 					__( 'Invalid connection type: %s', 'extended-cpts' ),
@@ -1863,7 +1863,7 @@ class Extended_CPT_Admin {
 			}
 		}
 
-		foreach ( $wp_query->post->$field as $post ) {
+		foreach ( $_post->$field as $post ) {
 
 			setup_postdata( $post );
 


### PR DESCRIPTION
This should fix issue #48 -- posts connected to the first post in the admin listing were being shown for all the subsequent posts. 

My fix makes it so it correctly shows the connected posts to the one in the current admin row you're displaying.
