### PR TITLE
support orderby meta_value_*

### DIFF
--- a/extended-cpts.php
+++ b/extended-cpts.php
@@ -451,8 +451,8 @@ class Extended_CPT {
 
 		if ( isset( $orderby['meta_key'] ) ) {
 			$return['meta_key'] = $orderby['meta_key'];
-			$return['orderby']  = 'meta_value';
-			// @TODO meta_value_num
+			// whatever user passed in orderby wordpress will be ignore none support value
+			$return['orderby']  = isset($orderby['orderby']) ? $orderby['orderby'] : 'meta_value';
 		} else if ( isset( $orderby['post_field'] ) ) {
 			$field = str_replace( 'post_', '', $orderby['post_field'] );
 			$return['orderby'] = $field;


### PR DESCRIPTION
add support pass orderby `meta_value_*` in site_sortables & admin_cols

> ```
> 'site_sortables' => array(
>     'meta_name' => array(
>         'meta_key' => 'meta_name',
>         'orderby' => 'meta_value_num',
>         'default' => 'desc',
>     )
> ),
> 
> 'admin_cols' => array(
>     // A meta field column:
>     'meta_name' => array(
>         'title'    => 'meta title',
>         'meta_key' => 'meta_name',
>         'orderby' => 'meta_value_num',
>         'default' => 'desc',
>     ),
> ),
> ```

for more information about `meta_value_*` look section “[Order & Orderby Parameters](https://codex.wordpress.org/Class_Reference/WP_Query)”
