### PR TITLE
Move filter field labels to placeholder

### DIFF
--- a/extended-cpts.php
+++ b/extended-cpts.php
@@ -1117,7 +1117,7 @@ class Extended_CPT_Admin {
 
 				# Output the search box:
 				?>
-				<label><?php printf( '%s:', esc_html( $filter['title'] ) ); ?>&nbsp;<input type="text" name="<?php echo esc_attr( $filter_key ); ?>" id="filter_<?php echo esc_attr( $filter_key ); ?>" value="<?php echo esc_attr( $value ); ?>" /></label>
+				<input type="text" name="<?php echo esc_attr( $filter_key ); ?>" id="filter_<?php echo esc_attr( $filter_key ); ?>" value="<?php echo esc_attr( $value ); ?>" placeholder="<?php echo esc_attr($filter['title']) ?>"/>
 				<?php
 
 			} else if ( isset( $filter['meta_exists'] ) ) {


### PR DESCRIPTION
This PR moves the labels on meta search fields (which show up to the left of the field) to be placeholders inside the field instead, saving space.

Before: https://cldup.com/SmDY-pmOFo.png

After: https://cldup.com/-M9aqo59sB.png