### PR TITLE
Test against 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ notifications:
         on_failure: always
 
 php:
+    - 7.2
     - 7.1
     - 7.0
 


### PR DESCRIPTION
Even though it is early we should start testing against PHP 7.2.