### PR TITLE
Improve support for non-integer dates in admin columns

### DIFF
--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -754,6 +754,10 @@ class Extended_CPT_Admin {
 			}
 
 			foreach ( $vals as $val ) {
+		                
+				if ( strtotime($val) ) {
+			                $val = strtotime($val);
+                		}
 
 				if ( is_numeric( $val ) ) {
 					$echo[] = date_i18n( $args['date_format'], $val );


### PR DESCRIPTION
Since `mysql2date()` only supports dates in the format of `'Y-m-d H:i:s'`, adding in a `strtotime()` check first will allow dates stored in other formats as strings to be used with the `date_format` filter.