### PR TITLE
removes title from required fields in admin columns

### DIFF
--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -643,8 +643,7 @@ class Extended_CPT_Admin {
 
 		$new_cols = [];
 		$keep = [
-			'cb',
-			'title',
+			'cb'
 		];
 
 		# Add existing columns we want to keep:


### PR DESCRIPTION
This resolves issue #79 by simply removing the requirement that the title column is kept in the admin table. If it's preferable to require this field at all times, we could always add it back if not found in the configuration. Personally I don't think it's necessary.