### PR TITLE
Adds support for value => label definitions in the admin filter options

### DIFF
--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -1215,9 +1215,10 @@ class Extended_CPT_Admin {
 
 
     /**
-     * @param $options
+     * Parses filter options into value => label pairs.
      *
-     * @return array
+     * @param array $options Filter options.
+     * @return array Filter options single dimension array.
      */
     public function parse_filter_options($options): array
     {

--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -270,22 +270,14 @@ class Extended_CPT_Admin {
 
 				$selected = wp_unslash( get_query_var( $filter_key ) );
 
-				$use_key = false;
+                $filter['options'] = $this->parse_filter_options($filter['options']);
 
-				foreach ( $filter['options'] as $k => $v ) {
-					if ( ! is_numeric( $k ) ) {
-						$use_key = true;
-						break;
-					}
-				}
-
-				# Output the dropdown:
+                # Output the dropdown:
 				?>
 				<select name="<?php echo esc_attr( $filter_key ); ?>" id="filter_<?php echo esc_attr( $filter_key ); ?>">
 					<option value=""><?php echo esc_html( $filter['title'] ); ?></option>
 					<?php
-					foreach ( $filter['options'] as $k => $v ) {
-						$key = ( $use_key ? $k : $v );
+					foreach ( $filter['options'] as $key => $v ) {
 					?>
 						<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $selected, $key ); ?>><?php echo esc_html( $v ); ?></option>
 					<?php } ?>
@@ -1220,5 +1212,34 @@ class Extended_CPT_Admin {
 		}
 		return $this->connection_exists[ $connection ];
 	}
+
+
+    /**
+     * @param $options
+     *
+     * @return array
+     */
+    public function parse_filter_options($options): array
+    {
+        $result = [];
+
+        foreach ( $options as $k => $v ) {
+            // Check if $v is an array of key, and value properties
+            if ( is_array($v) ) {
+                $value = $v['value'] ?? ($v['label'] ?? null);
+                $label = $v['label'] ?? $value;
+
+                if ( ! is_null($value) ) {
+                    $result[$value] = $label;
+                }
+            } else {
+                $key = !is_numeric($k) ? $k : $v;
+                $result[$key] = $v;
+            }
+
+        }
+
+        return $result;
+    }
 
 }

--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -270,9 +270,9 @@ class Extended_CPT_Admin {
 
 				$selected = wp_unslash( get_query_var( $filter_key ) );
 
-                $filter['options'] = $this->parse_filter_options($filter['options']);
+				$filter['options'] = $this->parse_filter_options( $filter['options'] );
 
-                # Output the dropdown:
+				# Output the dropdown:
 				?>
 				<select name="<?php echo esc_attr( $filter_key ); ?>" id="filter_<?php echo esc_attr( $filter_key ); ?>">
 					<option value=""><?php echo esc_html( $filter['title'] ); ?></option>
@@ -1214,33 +1214,32 @@ class Extended_CPT_Admin {
 	}
 
 
-    /**
-     * Parses filter options into value => label pairs.
-     *
-     * @param array $options Filter options.
-     * @return array Filter options single dimension array.
-     */
-    public function parse_filter_options($options): array
-    {
-        $result = [];
+	/**
+	 * Parses filter options into value => label pairs.
+	 *
+	 * @param array $options Filter options.
+	 *
+	 * @return array Filter options single dimension array.
+	 */
+	public function parse_filter_options( $options ) {
+		$result = [];
 
-        foreach ( $options as $k => $v ) {
-            // Check if $v is an array of key, and value properties
-            if ( is_array($v) ) {
-                $value = $v['value'] ?? ($v['label'] ?? null);
-                $label = $v['label'] ?? $value;
+		foreach ( $options as $k => $v ) {
+			// Check if $v is an array of key, and value properties
+			if ( is_array( $v ) ) {
+				$value = $v['value'] ?? ( $v['label'] ?? null );
+				$label = $v['label'] ?? $value;
 
-                if ( ! is_null($value) ) {
-                    $result[$value] = $label;
-                }
-            } else {
-                $key = !is_numeric($k) ? $k : $v;
-                $result[$key] = $v;
-            }
+				if ( ! is_null( $value ) ) {
+					$result[ $value ] = $label;
+				}
+			} else {
+				$key            = ! is_numeric( $k ) ? $k : $v;
+				$result[ $key ] = $v;
+			}
+		}
 
-        }
-
-        return $result;
-    }
+		return $result;
+	}
 
 }

--- a/tests/phpunit/extended-cpts-test-admin.php
+++ b/tests/phpunit/extended-cpts-test-admin.php
@@ -51,5 +51,4 @@ abstract class Extended_CPT_Test_Admin extends Extended_CPT_Test {
 		// reset
 		set_current_screen( 'front' );
 	}
-
 }

--- a/tests/phpunit/test-functions.php
+++ b/tests/phpunit/test-functions.php
@@ -1,0 +1,114 @@
+<?php
+class Extended_CPT_Functions_Test extends Extended_CPT_Test_Admin
+{
+
+    /**
+     * @dataProvider filterOptions
+     */
+    public function testParseFilterOptions($test, $expected)
+    {
+        $admin = new Extended_CPT_Admin(new Extended_CPT('test'));
+        $result = $admin->parse_filter_options($test);
+//        $ecptAdminMock = $this->getMockBuilder(Extended_CPT_Admin::class)
+//            ->disableOriginalConstructor()
+//            ->getMock();
+
+//        $result = $ecptAdminMock->parse_filter_options($test);
+
+        $this->assertEquals($result, $expected);
+    }
+
+    public function filterOptions()
+    {
+        return [
+            [
+                'test' => [],
+                'expected' => []
+            ],
+            [
+                'test' => [
+                    'Option One',
+                    'Option Two'
+                ],
+                'expected' => [
+                    'Option One' => 'Option One',
+                    'Option Two' => 'Option Two'
+                ]
+            ],
+            [
+                'test' => [
+                    1 => 'Option One',
+                    2 => 'Option Two'
+                ],
+                'expected' => [
+                    'Option One' => 'Option One',
+                    'Option Two' => 'Option Two'
+                ]
+            ],
+            [
+                'test' => [
+                    '1' => 'Option One',
+                    '2' => 'Option Two'
+                ],
+                'expected' => [
+                    'Option One' => 'Option One',
+                    'Option Two' => 'Option Two'
+                ]
+            ],
+            [
+                'test' => [
+                    [
+                        'value' => 0,
+                        'label' => 'Option One'
+                    ],
+                    [
+                        'value' => 1,
+                        'label' => 'Option Two'
+                    ],
+                ],
+                'expected' => [
+                    0 => 'Option One',
+                    1 => 'Option Two'
+                ]
+            ],
+            [
+                'test' => [
+                    [
+                        'value' => 'Option One',
+                    ],
+                    [
+                        'label' => 'Option Two'
+                    ],
+                ],
+                'expected' => [
+                    'Option One' => 'Option One',
+                    'Option Two' => 'Option Two'
+                ]
+            ],
+            [
+                'test' => [
+                    [
+                        'Option One',
+                    ],
+                    [
+                        'Option Two'
+                    ],
+                    'Option Three',
+                ],
+                'expected' => [
+                    'Option Three' => 'Option Three',
+                ]
+            ],
+            [
+                'test' => [
+                    'value' => 'Option One',
+                    'label' => 'Option Two'
+                ],
+                'expected' => [
+                    'value' => 'Option One',
+                    'label' => 'Option Two'
+                ]
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Hi John,

I never created a pull request on github before, so hopefully I didn't screw anything up.
So, I implemented the solution I described in my last comment here: 
https://github.com/johnbillion/extended-cpts/issues/87#issuecomment-384424130

I wrote a test too, but for some reason the mockBuilder would not execute my method and always returned `null`, so I had to instantiated the `Extended_CPT_Admin::class`.

Feel free to make adjustments or reject if this doesn't feel right to you.

Thanks for the consideration.