### PR TITLE
Add meta_format arg to admin col to allow formatting for display

### DIFF
--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -746,6 +746,12 @@ class Extended_CPT_Admin {
 					$echo[] = mysql2date( $args['date_format'], $val );
 				}
 			}
+		} elseif ( isset( $args['meta_format'] ) ) {
+				foreach ( $vals as $val ) {
+					if ( ! empty( $val ) || ( '0' === $val ) ) {
+						$echo[] = call_user_func( $args['meta_format'], $val );
+					}
+				}
 		} else {
 
 			foreach ( $vals as $val ) {


### PR DESCRIPTION
Full disclosure - I haven't run the tests or thought through potential security implications, but this is a feature missing compared to doing it manually. With the manual method you can have a "simple" column with a meta_value in it (so have sorting/filtering etc all work neatly), but use simple functions to affect display only such as `ucfirst`.

This adds a simply extra arg analgous to date_format called meta_format that is passed to call_use_func to be run on $val. 