### PR TITLE
option to disable block editor

### DIFF
--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -15,7 +15,7 @@ class Extended_CPT_Admin {
 		'admin_cols'         => null, # Custom arg
 		'admin_filters'      => null, # Custom arg
 		'enter_title_here'   => null, # Custom arg
-		'block_editor'       => true, # Custom arg
+		'block_editor'       => null, # Custom arg
 	];
 
 	/**
@@ -80,8 +80,9 @@ class Extended_CPT_Admin {
 		}
 
 		# Block editor filter:
-		if ( ! $this->args['block_editor'] ) {
-			add_filter( 'use_block_editor_for_post_type', [ $this, 'disable_block_editor' ], 10, 2 );
+		if ( ! is_null( $this->args['block_editor'] ) && is_bool( $this->args['block_editor'] ) ) {
+			$callback = $this->args['block_editor'] ? 'enable_block_editor' : 'disable_block_editor';
+			add_filter( 'use_block_editor_for_post_type', [ $this, $callback ], 101, 2 );
 		}
 
 		# Hide month filter:
@@ -195,6 +196,20 @@ class Extended_CPT_Admin {
 	public function disable_block_editor( bool $current_status, string $post_type ) : bool {
 		if ( $post_type === $this->cpt->post_type ) {
 			return false;
+		}
+		return $current_status;
+	}
+
+	/**
+	 * Enable the block editor if it matches this custom post type
+	 *
+	 * @param boolean $current_status The current status for the given post type.
+	 * @param string $post_type  The current post type.
+	 * @return boolean The updated current status.
+	 */
+	public function enable_block_editor( bool $current_status, string $post_type ) : bool {
+		if ( $post_type === $this->cpt->post_type ) {
+			return true;
 		}
 		return $current_status;
 	}

--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -15,6 +15,7 @@ class Extended_CPT_Admin {
 		'admin_cols'         => null, # Custom arg
 		'admin_filters'      => null, # Custom arg
 		'enter_title_here'   => null, # Custom arg
+		'block_editor'       => true, # Custom arg
 	];
 
 	/**
@@ -76,6 +77,11 @@ class Extended_CPT_Admin {
 		# 'Enter title here' filter:
 		if ( $this->args['enter_title_here'] ) {
 			add_filter( 'enter_title_here', [ $this, 'enter_title_here' ], 10, 2 );
+		}
+
+		# Block editor filter:
+		if ( ! $this->args['block_editor'] ) {
+			add_filter( 'use_block_editor_for_post_type', [ $this, 'disable_block_editor' ], 10, 2 );
 		}
 
 		# Hide month filter:
@@ -177,6 +183,20 @@ class Extended_CPT_Admin {
 		}
 
 		return $this->args['enter_title_here'];
+	}
+
+	/**
+	 * Disables the block editor if it matches this custom post type
+	 *
+	 * @param boolean $current_status The current status for the given post type.
+	 * @param string $post_type  The current post type.
+	 * @return boolean The updated current status.
+	 */
+	public function disable_block_editor( bool $current_status, string $post_type ) : bool {
+		if ( $post_type === $this->cpt->post_type ) {
+			return false;
+		}
+		return $current_status;
 	}
 
 	/**

--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -81,8 +81,7 @@ class Extended_CPT_Admin {
 
 		# Block editor filter:
 		if ( ! is_null( $this->args['block_editor'] ) && is_bool( $this->args['block_editor'] ) ) {
-			$callback = $this->args['block_editor'] ? 'enable_block_editor' : 'disable_block_editor';
-			add_filter( 'use_block_editor_for_post_type', [ $this, $callback ], 101, 2 );
+			add_filter( 'use_block_editor_for_post_type', [ $this, 'block_editor' ], 101, 2 );
 		}
 
 		# Hide month filter:
@@ -187,29 +186,15 @@ class Extended_CPT_Admin {
 	}
 
 	/**
-	 * Disables the block editor if it matches this custom post type
+	 * Enable or disable the block editor if it matches this custom post type
 	 *
 	 * @param boolean $current_status The current status for the given post type.
 	 * @param string $post_type  The current post type.
 	 * @return boolean The updated current status.
 	 */
-	public function disable_block_editor( bool $current_status, string $post_type ) : bool {
+	public function block_editor( bool $current_status, string $post_type ) : bool {
 		if ( $post_type === $this->cpt->post_type ) {
-			return false;
-		}
-		return $current_status;
-	}
-
-	/**
-	 * Enable the block editor if it matches this custom post type
-	 *
-	 * @param boolean $current_status The current status for the given post type.
-	 * @param string $post_type  The current post type.
-	 * @return boolean The updated current status.
-	 */
-	public function enable_block_editor( bool $current_status, string $post_type ) : bool {
-		if ( $post_type === $this->cpt->post_type ) {
-			return true;
+			return $this->args['block_editor'];
 		}
 		return $current_status;
 	}


### PR DESCRIPTION
I find it very useful for my projects to be able to disable Gutenberg on specific CPTs, since they don't use an editor. 
It would be enabled by default and disabled on request, with an admin parameter. 
I can update the docs, if it's approved.