### PR TITLE
Fixes dropdown for hierarchical taxonomies

### DIFF
--- a/src/class-extended-taxonomy-admin.php
+++ b/src/class-extended-taxonomy-admin.php
@@ -434,7 +434,7 @@ class Extended_Taxonomy_Admin {
 						'orderby'           => 'name',
 						'selected'          => reset( $selected ),
 						'id'                => "{$taxonomy}dropdown",
-						'name'              => "tax_input[{$taxonomy}]",
+						'name'              => is_taxonomy_hierarchical( $taxonomy ) ? "tax_input[{$taxonomy}][]" : "tax_input[{$taxonomy}]",
 						'taxonomy'          => $taxonomy,
 						'walker'            => $walker,
 						'required'          => $this->args['required'],


### PR DESCRIPTION
When choosing to display a hierarchical taxonomy as a dropdown, the input name was incorrect. This PR takes into account both hierarchical and non-hierarchical taxonomies to output the correct input name.