### PR TITLE
(fix): add back_compat_meta_box for taxonomies

### DIFF
--- a/src/class-extended-taxonomy-admin.php
+++ b/src/class-extended-taxonomy-admin.php
@@ -325,13 +325,19 @@ class Extended_Taxonomy_Admin {
 
 				# Add the meta box, using the plural or singular taxonomy label where relevant:
 				if ( $this->taxo->args['exclusive'] ) {
-					add_meta_box( "{$this->taxo->taxonomy}div", $tax->labels->singular_name, $this->args['meta_box'], $post_type, 'side' );
+					add_meta_box( "{$this->taxo->taxonomy}div", $tax->labels->singular_name, $this->args['meta_box'], $post_type, 'side', 'default', [
+						'__back_compat_meta_box' => true,
+					] );
 				} else {
-					add_meta_box( "{$this->taxo->taxonomy}div", $tax->labels->name, $this->args['meta_box'], $post_type, 'side' );
+					add_meta_box( "{$this->taxo->taxonomy}div", $tax->labels->name, $this->args['meta_box'], $post_type, 'side', 'default', [
+						'__back_compat_meta_box' => true,
+					] );
 				}
 			} elseif ( false !== $this->args['meta_box'] ) {
 				# This must be an 'exclusive' taxonomy. Add the radio meta box:
-				add_meta_box( "{$this->taxo->taxonomy}div", $tax->labels->singular_name, [ $this, 'meta_box_radio' ], $post_type, 'side' );
+				add_meta_box( "{$this->taxo->taxonomy}div", $tax->labels->singular_name, [ $this, 'meta_box_radio' ], $post_type, 'side', 'default', [
+					'__back_compat_meta_box' => true,
+				] );
 			}
 		}
 	}
@@ -597,3 +603,4 @@ class Extended_Taxonomy_Admin {
 	}
 
 }
+


### PR DESCRIPTION
Issue #118 states that there are duplicate metaboxes for the taxonomies.

After some research, it seems that the `add_meta_box` function (https://developer.wordpress.org/reference/functions/add_meta_box/) allows for `$callback_args` which can be utilized for this issue.

Gary Pendergast has written a post about the compatibility for the metaboxes for Gutenberg (https://make.wordpress.org/core/2018/11/07/meta-box-compatibility-flags/).

Thus, adding the flag`'__back_compat_meta_box' => true` to the `add_meta_box` function, fixes the issue of duplicate metaboxes.

Before the fix:
![before](https://user-images.githubusercontent.com/4084596/76954775-3606d780-6911-11ea-9db5-7a14af2a1018.png)

After the fix:
![after](https://user-images.githubusercontent.com/4084596/76954783-3901c800-6911-11ea-9b99-049bb7d29e9c.png)

> Note the duplicate (light gray) taxonomies "Functiecategorieen" and "Politieke partijen"


This has been tested with and without Gutenberg.

The only thing which isn't working (but didn't work before my patch), are the radiobuttons instead of checkboxes.

I haven't got the tests running, as I don't have MySQL running locally (I'm working with docker containers), and the tests are complaining that they cannot connect to local MySQL server through socket.