### PR TITLE
Remove the taxonomy meta box from the block editor

### DIFF
--- a/src/class-extended-taxonomy-admin.php
+++ b/src/class-extended-taxonomy-admin.php
@@ -296,12 +296,21 @@ class Extended_Taxonomy_Admin {
 		if ( in_array( $this->taxo->taxonomy, $taxos, true ) ) {
 			$tax = get_taxonomy( $this->taxo->taxonomy );
 
-			# Remove default meta box:
+			# Remove default meta box from classic editor:
 			if ( $this->taxo->args['hierarchical'] ) {
 				remove_meta_box( "{$this->taxo->taxonomy}div", $post_type, 'side' );
 			} else {
 				remove_meta_box( "tagsdiv-{$this->taxo->taxonomy}", $post_type, 'side' );
 			}
+
+			# Remove default meta box from block editor:
+			wp_add_inline_script(
+				'wp-edit-post',
+				sprintf(
+					'wp.data.dispatch( "core/edit-post" ).removeEditorPanel( "taxonomy-panel-%s" );',
+					$this->taxo->taxonomy
+				)
+			);
 
 			if ( ! current_user_can( $tax->cap->assign_terms ) ) {
 				return;


### PR DESCRIPTION
This allows just the one from Extended CPTs to be used, which means the custom meta boxes such as `radio` work as expected both in the block editor and in the classic editor.

This is essentially the opposite behaviour of #132 which allows only the block editor meta box to be used.

See #118.

<img width="277" alt="" src="https://user-images.githubusercontent.com/208434/86542111-db6ea700-bf12-11ea-9880-2c151d1aae6c.png">
