### PR TITLE
Add filters for post type and taxonomy arguments and names

### DIFF
--- a/src/class-extended-cpt.php
+++ b/src/class-extended-cpt.php
@@ -92,6 +92,16 @@ class Extended_CPT {
 		$args  = apply_filters( "ext-cpts/{$post_type}/args", $args );
 
 		/**
+		 * Filter the names for all post types.
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param string[] $names The plural, singular, and slug names (if any were specified).
+		 * @param string $post_type The post type name.
+		 */
+		$names = apply_filters( 'ext-cpts/names', $names, $post_type );
+
+		/**
 		 * Filter the names for this post type.
 		 *
 		 * @since 2.4.0

--- a/src/class-extended-cpt.php
+++ b/src/class-extended-cpt.php
@@ -73,14 +73,14 @@ class Extended_CPT {
 	 */
 	public function __construct( string $post_type, array $args = [], array $names = [] ) {
 		/**
-		 * Filter the arguments for all post types.
+		 * Filter the arguments for a post type.
 		 *
-		 * @since 5.0.0
+		 * @since 4.4.1
 		 *
-		 * @param array $args The post type arguments.
+		 * @param array  $args      The post type arguments.
 		 * @param string $post_type The post type name.
 		 */
-		$args  = apply_filters( 'ext-cpts/args', $args, $post_type );
+		$args = apply_filters( 'ext-cpts/args', $args, $post_type );
 
 		/**
 		 * Filter the arguments for this post type.
@@ -89,20 +89,20 @@ class Extended_CPT {
 		 *
 		 * @param array $args The post type arguments.
 		 */
-		$args  = apply_filters( "ext-cpts/{$post_type}/args", $args );
+		$args = apply_filters( "ext-cpts/{$post_type}/args", $args );
 
 		/**
-		 * Filter the names for all post types.
+		 * Filter the plural, singular, and slug names for a post type.
 		 *
-		 * @since 5.0.0
+		 * @since 4.4.1
 		 *
-		 * @param string[] $names The plural, singular, and slug names (if any were specified).
-		 * @param string $post_type The post type name.
+		 * @param string[] $names     The plural, singular, and slug names (if any were specified).
+		 * @param string   $post_type The post type name.
 		 */
 		$names = apply_filters( 'ext-cpts/names', $names, $post_type );
 
 		/**
-		 * Filter the names for this post type.
+		 * Filter the plural, singular, and slug names for this post type.
 		 *
 		 * @since 2.4.0
 		 *

--- a/src/class-extended-cpt.php
+++ b/src/class-extended-cpt.php
@@ -73,6 +73,16 @@ class Extended_CPT {
 	 */
 	public function __construct( string $post_type, array $args = [], array $names = [] ) {
 		/**
+		 * Filter the arguments for all post types.
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param array $args The post type arguments.
+		 * @param string $post_type The post type name.
+		 */
+		$args  = apply_filters( 'ext-cpts/args', $args, $post_type );
+
+		/**
 		 * Filter the arguments for this post type.
 		 *
 		 * @since 2.4.0

--- a/src/class-extended-taxonomy.php
+++ b/src/class-extended-taxonomy.php
@@ -70,6 +70,16 @@ class Extended_Taxonomy {
 	 */
 	public function __construct( string $taxonomy, $object_type, array $args = [], array $names = [] ) {
 		/**
+		 * Filter the arguments for all taxonomies.
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param array $args The taxonomy arguments.
+		 * @param string $taxonomy The taxonomy name.
+		 */
+		$args  = apply_filters( 'ext-taxos/args', $args, $taxonomy );
+
+		/**
 		 * Filter the arguments for this taxonomy.
 		 *
 		 * @since 2.0.0

--- a/src/class-extended-taxonomy.php
+++ b/src/class-extended-taxonomy.php
@@ -89,6 +89,16 @@ class Extended_Taxonomy {
 		$args  = apply_filters( "ext-taxos/{$taxonomy}/args", $args );
 
 		/**
+		 * Filter the names for all taxonomies.
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param string[] $names The plural, singular, and slug names (if any were specified).
+		 * @param string $taxonomy The taxonomy name.
+		 */
+		$names = apply_filters( 'ext-taxos/names', $names, $taxonomy );
+
+		/**
 		 * Filter the names for this taxonomy.
 		 *
 		 * @since 2.0.0

--- a/src/class-extended-taxonomy.php
+++ b/src/class-extended-taxonomy.php
@@ -70,14 +70,14 @@ class Extended_Taxonomy {
 	 */
 	public function __construct( string $taxonomy, $object_type, array $args = [], array $names = [] ) {
 		/**
-		 * Filter the arguments for all taxonomies.
+		 * Filter the arguments for a taxonomy.
 		 *
-		 * @since 5.0.0
+		 * @since 4.4.1
 		 *
-		 * @param array $args The taxonomy arguments.
+		 * @param array  $args     The taxonomy arguments.
 		 * @param string $taxonomy The taxonomy name.
 		 */
-		$args  = apply_filters( 'ext-taxos/args', $args, $taxonomy );
+		$args = apply_filters( 'ext-taxos/args', $args, $taxonomy );
 
 		/**
 		 * Filter the arguments for this taxonomy.
@@ -86,20 +86,20 @@ class Extended_Taxonomy {
 		 *
 		 * @param array $args The taxonomy arguments.
 		 */
-		$args  = apply_filters( "ext-taxos/{$taxonomy}/args", $args );
+		$args = apply_filters( "ext-taxos/{$taxonomy}/args", $args );
 
 		/**
-		 * Filter the names for all taxonomies.
+		 * Filter the plural, singular, and slug for a taxonomy.
 		 *
-		 * @since 5.0.0
+		 * @since 4.4.1
 		 *
-		 * @param string[] $names The plural, singular, and slug names (if any were specified).
-		 * @param string $taxonomy The taxonomy name.
+		 * @param string[] $names    The plural, singular, and slug names (if any were specified).
+		 * @param string   $taxonomy The taxonomy name.
 		 */
 		$names = apply_filters( 'ext-taxos/names', $names, $taxonomy );
 
 		/**
-		 * Filter the names for this taxonomy.
+		 * Filter the plural, singular, and slug for this taxonomy.
 		 *
 		 * @since 2.0.0
 		 *


### PR DESCRIPTION
PR related to #151 

This PR adds filters for the post type names and arguments as well as the taxonomy names and arguments. It is a more general hook name than what is already present and passes the post type name or taxonomy name as a parameter to allow additional logic inside our callbacks.

Potential use cases below.

```
add_filter( 'ext-cpts/args', function( $args, $post_type ) {
    if ( 'story' === $post_type ) {
	// Some logic.
    }
    return $args;
}, 10, 2 );
```

```
add_filter( 'ext-cpts/names', function( $names, $post_type ) {
    if ( 'story' === $post_type ) {
	// Some logic.
    }
    return $names;
}, 10, 2 );
```

```
add_filter( 'ext-taxos/args', function( $args, $taxonomy ) {
    if ( 'genre' === $taxonomy ) {
	// Some logic.
    }
    return $args;
}, 10, 2 );
```

```
add_filter( 'ext-taxos/names', function( $names, $taxonomy ) {
    if ( 'genre' === $taxonomy ) {
	// Some logic.
    }
    return $names;
}, 10, 2 );
```