### PR TITLE
Add an action to access the Extended_CPT_Admin instances

### DIFF
--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -116,6 +116,15 @@ class Extended_CPT_Admin {
 		# Post updated messages:
 		add_filter( 'post_updated_messages',      [ $this, 'post_updated_messages' ], 1 );
 		add_filter( 'bulk_post_updated_messages', [ $this, 'bulk_post_updated_messages' ], 1, 2 );
+
+		/**
+		 * Fired when the extended post type admin instance is set up.
+		 *
+		 * @todo Add @since tag when version is bumped.
+		 *
+		 * @param Extended_CPT_Admin $instance The extended post type admin instance.
+		 */
+		do_action( "ext-cpts-admin/{$this->cpt->post_type}/instance", $this );
 	}
 
 	/**


### PR DESCRIPTION
Hello,

First of all, thanks for this great project. It really speeds up WordPress development.

While working on a project, I needed to access a `Extended_CPT_Admin` instance but could not find a way to do so.
I came up with the idea of adapting the existing `ext-cpts/{$post_type}/instance` hook, this PR is basically a copy-paste :laughing:

Feel free to close this PR if you don't think this is necessary or let me know if you'd like some change, like the name of the hook for instance.