### PR TITLE
Remove redundant PHPStan config

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,10 +6,6 @@ parameters:
     paths:
         - functions.php
         - src/
-    scanFiles:
-        - functions.php
-    scanDirectories:
-        - src/
     ignoreErrors:
         # Uses func_get_args()
         - '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'


### PR DESCRIPTION
PHPStan scans all files in `paths:`