### PR TITLE
Added branch alias for upcoming major release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
 		"preferred-install": "dist"
 	},
 	"extra": {
+    "branch-alias": {
+      "dev-develop": "5.0-dev"
+    },
 		"wordpress-install-dir": "tests/wordpress"
 	},
 	"require": {

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
 		"preferred-install": "dist"
 	},
 	"extra": {
-    "branch-alias": {
-      "dev-develop": "5.0-dev"
-    },
+		"branch-alias": {
+			"dev-develop": "5.0-dev"
+		},
 		"wordpress-install-dir": "tests/wordpress"
 	},
 	"require": {


### PR DESCRIPTION
This will allow us to test the latest version using a version number instead of requiring `dev-develop` which might break once the next major version is released.