### PR TITLE
Fix Broken Display of Timestamp Meta Values in Admin Columns

### DIFF
--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -380,7 +380,7 @@ class Extended_CPT_Admin {
 
 				# Output the search box:
 				?>
-				<label for="<?php echo esc_attr( $id ); ?>"><?php printf( '%s:', esc_html( $filter['title'] ) ); ?></label>&nbsp;<input type="text" name="<?php echo esc_attr( $filter_key ); ?>" id="<?php echo esc_attr( $id ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+				<label for="<?php echo esc_attr( $id ); ?>" class="screen-reader-text"><?php printf( '%s:', esc_html( $filter['title'] ) ); ?>&nbsp;</label><input type="text" name="<?php echo esc_attr( $filter_key ); ?>" id="<?php echo esc_attr( $id ); ?>" value="<?php echo esc_attr( $value ); ?>" placeholder="<?php echo esc_html( $filter['title'] ) ?>" />
 				<?php
 			} elseif ( isset( $filter['meta_exists'] ) || isset( $filter['meta_key_exists'] ) ) {
 				# If we haven't specified a title, use the all_items label from the post type:

--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -380,7 +380,7 @@ class Extended_CPT_Admin {
 
 				# Output the search box:
 				?>
-				<label for="<?php echo esc_attr( $id ); ?>" class="screen-reader-text"><?php printf( '%s:', esc_html( $filter['title'] ) ); ?>&nbsp;</label><input type="text" name="<?php echo esc_attr( $filter_key ); ?>" id="<?php echo esc_attr( $id ); ?>" value="<?php echo esc_attr( $value ); ?>" placeholder="<?php echo esc_html( $filter['title'] ) ?>" />
+				<label for="<?php echo esc_attr( $id ); ?>"><?php printf( '%s:', esc_html( $filter['title'] ) ); ?></label>&nbsp;<input type="text" name="<?php echo esc_attr( $filter_key ); ?>" id="<?php echo esc_attr( $id ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 				<?php
 			} elseif ( isset( $filter['meta_exists'] ) || isset( $filter['meta_key_exists'] ) ) {
 				# If we haven't specified a title, use the all_items label from the post type:

--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -917,6 +917,13 @@ ICONCSS;
 			foreach ( $vals as $val ) {
 				$val_time = strtotime( $val );
 
+				try {
+					new DateTime ( '@' . $val );
+					$val_time = strtotime( '@' . $val );
+				} catch ( Exception $e ) {
+					$val_time = strtotime( $val );
+				}
+
 				if ( $val_time ) {
 					$val = $val_time;
 				}


### PR DESCRIPTION
Fixes what's reported in https://github.com/johnbillion/extended-cpts/issues/105, using @cgarofalo's simple method which they proposed in [this comment](https://github.com/johnbillion/extended-cpts/issues/105#issuecomment-974347853) on that original issue thread. 