### PR TITLE
Fix Broken Display of Timestamp Meta Values in Admin Columns

### DIFF
--- a/src/PostTypeAdmin.php
+++ b/src/PostTypeAdmin.php
@@ -5,6 +5,8 @@ namespace ExtCPTs;
 
 use WP_Post;
 use WP_Query;
+use DateTime;
+use Exception;
 
 use function p2p_connection_exists;
 use function p2p_type;
@@ -987,6 +989,13 @@ ICONCSS;
 
 			foreach ( $vals as $val ) {
 				$val_time = strtotime( $val );
+
+				try {
+					new DateTime ( '@' . $val );
+					$val_time = strtotime( '@' . $val );
+				} catch ( Exception $e ) {
+					$val_time = strtotime( $val );
+				}
 
 				if ( false !== $val_time ) {
 					$val = $val_time;

--- a/src/PostTypeAdmin.php
+++ b/src/PostTypeAdmin.php
@@ -988,11 +988,8 @@ ICONCSS;
 			}
 
 			foreach ( $vals as $val ) {
-				$val_time = strtotime( $val );
-
 				try {
-					new DateTime ( '@' . $val );
-					$val_time = strtotime( '@' . $val );
+					$val_time = ( new DateTime( '@' . $val ) )->format( 'U' );
 				} catch ( Exception $e ) {
 					$val_time = strtotime( $val );
 				}


### PR DESCRIPTION
Fixes what's reported in https://github.com/johnbillion/extended-cpts/issues/105, using @cgarofalo's simple method which they proposed in [this comment](https://github.com/johnbillion/extended-cpts/issues/105#issuecomment-974347853) on that original issue thread. 