### PR TITLE
Use title parameter as column title when set

### DIFF
--- a/src/PostTypeAdmin.php
+++ b/src/PostTypeAdmin.php
@@ -1396,9 +1396,9 @@ ICONCSS;
 	 * @return string The item title.
 	 */
 	protected function get_item_title( array $item, string $fallback = '' ): string {
-        if ( isset( $item['title'] ) ) {
+		if ( isset( $item['title'] ) ) {
 			return $item['title'];
-        } elseif ( isset( $item['taxonomy'] ) ) {
+		} elseif ( isset( $item['taxonomy'] ) ) {
 			$tax = get_taxonomy( $item['taxonomy'] );
 			if ( $tax ) {
 				if ( ! empty( $tax->exclusive ) ) {

--- a/src/PostTypeAdmin.php
+++ b/src/PostTypeAdmin.php
@@ -1396,7 +1396,9 @@ ICONCSS;
 	 * @return string The item title.
 	 */
 	protected function get_item_title( array $item, string $fallback = '' ): string {
-		if ( isset( $item['taxonomy'] ) ) {
+        if ( isset( $item['title'] ) ) {
+			return $item['title'];
+        } elseif ( isset( $item['taxonomy'] ) ) {
 			$tax = get_taxonomy( $item['taxonomy'] );
 			if ( $tax ) {
 				if ( ! empty( $tax->exclusive ) ) {


### PR DESCRIPTION
Setting the column title using the `title` parameter doesn't work with version 5.0.0.

```
'my_column' => array(
	'title'    => 'Hello World',
	'function' => function() {
		echo 'Hello, World!';
	},
),
```

The column title shows as `my_column` instead of `Hello World`.

![image](https://user-images.githubusercontent.com/50170696/152866646-a8dc0a6c-d2fb-4e25-b9b5-86c157b2ee08.png)
