### PR TITLE
Check if a post type has been returned before altering its messages

### DIFF
--- a/src/PostTypeAdmin.php
+++ b/src/PostTypeAdmin.php
@@ -710,6 +710,10 @@ ICONCSS;
 
 		/** @var \WP_Post_Type */
 		$pto = get_post_type_object( $this->cpt->post_type );
+		
+		if (is_null($pto)) {
+            return $messages;
+        }
 
 		$messages[ $this->cpt->post_type ] = [
 			1 => sprintf(


### PR DESCRIPTION
Fixes an obscure bug that seems to be caused by registering a CPT without editor support.

For context:
I am running a multi-site installation of WordPress. Each site runs the same theme, which gets initialized with a number of CPTs configured using [log1x/poet](github.com/log1x/poet/). At some point in the initialization process, a few of the initial CPTs get unregistered for specific sites. For whatever reason, this causes some of the remaining CPTs to "break"--attempting to create a CPT item throws the following error (you'll note I'm using an older version of the library, but the same outcome occurs on v5.x):

``` sh
[2022-05-27 18:11:47] production.ERROR: Trying to get property 'publicly_queryable' of non-object {"userId":1,"exception":"[object] (ErrorException(code: 0): Trying to get property 'publicly_queryable' of non-object at C:\\home\\site\\wwwroot\\wp-content\\themes\\compass-theme\\vendor\\johnbillion\\extended-cpts\\src\\class-extended-cpt-admin.php:659)
[stacktrace]
#0 C:\\home\\site\\wwwroot\\wp-content\\themes\\compass-theme\\vendor\\johnbillion\\extended-cpts\\src\\class-extended-cpt-admin.php(659): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 C:\\home\\site\\wwwroot\\wp-includes\\class-wp-hook.php(307): Extended_CPT_Admin->post_updated_messages()
#2 C:\\home\\site\\wwwroot\\wp-includes\\plugin.php(189): WP_Hook->apply_filters()
#3 C:\\home\\site\\wwwroot\\wp-admin\\edit-form-advanced.php(219): apply_filters()
#4 C:\\home\\site\\wwwroot\\wp-admin\\post-new.php(75): require('C:\\\\home\\\\site\\\\ww...')
#5 {main}
"} 
```
Oddly, this only happens when the CPT was created _without_ editor support. CPTs that use the Gutenberg editor are unaffected. 


```    
