### PR TITLE
Updated johnbillion/args to 1.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	},
 	"require": {
 		"php": ">= 7.4.0",
-		"johnbillion/args": "^0.9.0"
+		"johnbillion/args": "^1.4.1"
 	},
 	"require-dev": {
 		"automattic/phpcs-neutron-standard": "1.7.0",


### PR DESCRIPTION
Not sure if this will cause any side effects, haven't tested it locally. Hopefully this will fix the following issue: it is not currently possible to run the latest version of `johnbillion/args` with the latest version of `johnbillion/extended-cpts`:

```
  Problem 1
    - Root composer.json requires johnbillion/args ^1.4, found johnbillion/args[1.4.0, 1.4.1] but these were not loaded, likely because it conflicts with another require.
  Problem 2
    - johnbillion/extended-cpts is locked to version 5.0.2 and an update of this package was not requested.
    - johnbillion/extended-cpts 5.0.2 requires johnbillion/args ^0.9.0 -> found johnbillion/args[0.9.0] but it conflicts with your root composer.json require (^1.4).
```

It seems the tests are passing for PHP 8 and fail on 7.4.