### PR TITLE
Remove redundant debug info from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,15 +55,9 @@ jobs:
         extensions: mysqli, xmlwriter
         coverage: none
 
-    - name: Debugging
-      run: |
-        php --version
-        php -m
-        composer --version
-        mysql --version
-
     - name: Install dependencies
       run: |
+        mysql --version
         sudo systemctl start mysql.service
         composer require --dev --update-with-dependencies --prefer-dist roots/wordpress-full="~${{ matrix.wp }}.0"
         mysqladmin -uroot -proot create wordpress_test


### PR DESCRIPTION
Those are already displayed in `shivammathur/setup-php`

![image](https://github.com/johnbillion/extended-cpts/assets/952007/9effc2c9-fb56-4899-ae5a-da94dbd890da)
