### PR TITLE
composer: allow installation of `johnbillion/args:^2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	"homepage": "https://github.com/johnbillion/extended-cpts/",
 	"require": {
 		"php": ">= 7.4.0",
-		"johnbillion/args": "^1.4.1"
+		"johnbillion/args": "^1.4.1 || ^2.0"
 	},
 	"require-dev": {
 		"automattic/phpcs-neutron-standard": "1.7.0",


### PR DESCRIPTION
Fixes #240 

I'm not sure if there's anything else that would need to be done here, but I hope that the tests will answer that.  I'll also try it out in development.