### PR TITLE
Skip the package caches when running nightly tests

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -42,3 +42,4 @@ jobs:
       wp: 'nightly'
       php: ${{ matrix.php }}
       node: false
+      cache: false


### PR DESCRIPTION
This allows the latest nightly to always be used.