### PR TITLE
Split `autoload` section, add `autoload-dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,16 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"ExtCPTs\\": "src",
-			"ExtCPTs\\Tests\\": "tests/integration"
+			"ExtCPTs\\": "src"
 		},
 		"files": [
 			"functions.php"
 		]
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"ExtCPTs\\Tests\\": "tests/integration"
+		}
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
Someone had an issue where the [namespace prefixer tool](https://github.com/BrianHenryIE/strauss) I maintain is using the `autoload` key to look for files to process, and the tests directory is missing. 

I presume they have run `composer install --no-dev` and the `tests` directory is absent, per [`.gitattributes`](https://github.com/BrianHenryIE/extended-cpts/blob/31cf3a554ce6e92e8e15e4a2148170bc18bd79a8/.gitattributes#L5).

https://github.com/BrianHenryIE/strauss/issues/190