### PR TITLE
Apply site sortables to taxonomy archives

### DIFF
--- a/src/PostType.php
+++ b/src/PostType.php
@@ -309,7 +309,7 @@ class PostType {
 	 * @param WP_Query $wp_query The current WP_Query object.
 	 */
 	public function maybe_sort_by_fields( WP_Query $wp_query ): void {
-		if ( empty( $wp_query->query['post_type'] ) || ! in_array( $this->post_type, (array) $wp_query->query['post_type'], true ) ) {
+		if ( ! $this->query_applies_to_post_type( $wp_query ) ) {
 			return;
 		}
 
@@ -345,7 +345,7 @@ class PostType {
 	 * @return array<string,string> Array of SQL clauses.
 	 */
 	public function maybe_sort_by_taxonomy( array $clauses, WP_Query $wp_query ): array {
-		if ( empty( $wp_query->query['post_type'] ) || ! in_array( $this->post_type, (array) $wp_query->query['post_type'], true ) ) {
+		if ( ! $this->query_applies_to_post_type( $wp_query ) ) {
 			return $clauses;
 		}
 
@@ -356,6 +356,286 @@ class PostType {
 		}
 
 		return array_merge( $clauses, $sort );
+	}
+
+	/**
+	 * Determines whether the query targets this post type or one of its taxonomy archives.
+	 *
+	 * @param WP_Query $wp_query The current WP_Query object.
+	 */
+	private function query_applies_to_post_type( WP_Query $wp_query ): bool {
+		if ( ! empty( $wp_query->query['post_type'] ) ) {
+			return in_array( $this->post_type, (array) $wp_query->query['post_type'], true );
+		}
+
+		$tax_query = null;
+
+		if ( ! empty( $wp_query->query['tax_query'] ) && is_array( $wp_query->query['tax_query'] ) ) {
+			$tax_query = $wp_query->query['tax_query'];
+		}
+
+		$taxonomies = get_object_taxonomies( $this->post_type );
+
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( $this->query_has_taxonomy_var( $wp_query->query, $taxonomy ) && $this->taxonomy_only_applies_to_post_type( $taxonomy ) ) {
+				if ( null !== $tax_query ) {
+					return $this->tax_query_only_applies_to_post_type( $this->tax_query_with_archive_clause( $tax_query, $taxonomy ) );
+				}
+
+				return true;
+			}
+		}
+
+		if (
+			isset( $wp_query->query['taxonomy'] )
+			&&
+			is_string( $wp_query->query['taxonomy'] )
+			&&
+			// Match WP_Query::parse_tax_query(), which only builds this legacy taxonomy query for non-empty terms.
+			! empty( $wp_query->query['term'] )
+			&&
+			$this->taxonomy_only_applies_to_post_type( $wp_query->query['taxonomy'] )
+		) {
+			if ( null !== $tax_query ) {
+				return $this->tax_query_only_applies_to_post_type( $this->tax_query_with_archive_clause( $tax_query, $wp_query->query['taxonomy'] ) );
+			}
+
+			return true;
+		}
+
+		if ( null === $tax_query ) {
+			return false;
+		}
+
+		return $this->tax_query_only_applies_to_post_type( $tax_query );
+	}
+
+	/**
+	 * Determines whether the query includes a taxonomy's query variable.
+	 *
+	 * @param array<string,mixed> $query    Query arguments.
+	 * @param string              $taxonomy Taxonomy name.
+	 */
+	private function query_has_taxonomy_var( array $query, string $taxonomy ): bool {
+		$taxonomy_object = get_taxonomy( $taxonomy );
+
+		if (
+			! ( $taxonomy_object instanceof WP_Taxonomy )
+			||
+			! is_string( $taxonomy_object->query_var )
+		) {
+			return false;
+		}
+
+		// Match WP_Query::parse_tax_query(), which skips empty public taxonomy query vars, including "0".
+		return ! empty( $query[ $taxonomy_object->query_var ] );
+	}
+
+	/**
+	 * Adds a taxonomy archive clause to an explicit tax_query.
+	 *
+	 * @param array<int|string,mixed> $tax_query Tax query arguments.
+	 * @param string                  $taxonomy  Taxonomy name.
+	 * @return array<int|string,mixed> Tax query arguments.
+	 */
+	private function tax_query_with_archive_clause( array $tax_query, string $taxonomy ): array {
+		$tax_query[] = [
+			'taxonomy' => $taxonomy,
+			'operator' => 'EXISTS',
+		];
+
+		return $tax_query;
+	}
+
+	/**
+	 * Determines whether every taxonomy clause in a tax_query belongs to this post type.
+	 *
+	 * @param array<int|string,mixed> $tax_query Tax query arguments.
+	 */
+	private function tax_query_only_applies_to_post_type( array $tax_query ): bool {
+		$tax_query_clauses = $this->get_tax_query_clauses( $tax_query );
+
+		if ( empty( $tax_query_clauses ) ) {
+			return false;
+		}
+
+		if ( $this->tax_query_has_or_negative_clause( $tax_query, false ) ) {
+			return false;
+		}
+
+		$has_positive_clause = false;
+
+		foreach ( $tax_query_clauses as $tax_query_clause ) {
+			if ( ! $this->taxonomy_only_applies_to_post_type( $tax_query_clause['taxonomy'] ) ) {
+				return false;
+			}
+
+			if ( ! $this->tax_query_operator_is_negative( $tax_query_clause['operator'] ) ) {
+				$has_positive_clause = true;
+			}
+		}
+
+		return $has_positive_clause;
+	}
+
+	/**
+	 * Gets the taxonomy clauses from a tax_query.
+	 *
+	 * @param array<int|string,mixed> $tax_query Tax query arguments.
+	 * @return array<int,array{taxonomy:string,operator:?string}>|null Taxonomy clauses, or null when an invalid clause is found.
+	 */
+	private function get_tax_query_clauses( array $tax_query ): ?array {
+		$tax_query_clauses = [];
+
+		foreach ( $tax_query as $key => $tax_query_item ) {
+			if ( 'relation' === $key ) {
+				continue;
+			}
+
+			if ( ! is_array( $tax_query_item ) ) {
+				return null;
+			}
+
+			if ( array_key_exists( 'taxonomy', $tax_query_item ) ) {
+				if ( ! is_string( $tax_query_item['taxonomy'] ) ) {
+					return null;
+				}
+
+				$operator = null;
+
+				if ( array_key_exists( 'operator', $tax_query_item ) ) {
+					if ( ! is_string( $tax_query_item['operator'] ) ) {
+						return null;
+					}
+
+					$operator = $tax_query_item['operator'];
+				}
+
+				if ( ! $this->tax_query_clause_constrains_query( $tax_query_item, $operator ) ) {
+					continue;
+				}
+
+				$tax_query_clauses[] = [
+					'taxonomy' => $tax_query_item['taxonomy'],
+					'operator' => $operator,
+				];
+				continue;
+			}
+
+			$nested_tax_query_clauses = $this->get_tax_query_clauses( $tax_query_item );
+
+			if ( null === $nested_tax_query_clauses ) {
+				return null;
+			}
+
+			$tax_query_clauses = array_merge( $tax_query_clauses, $nested_tax_query_clauses );
+		}
+
+		return $tax_query_clauses;
+	}
+
+	/**
+	 * Determines whether a tax_query clause can emit SQL that constrains results.
+	 *
+	 * @param array<string,mixed> $tax_query_clause Tax query clause.
+	 * @param ?string             $operator         Tax query operator.
+	 */
+	private function tax_query_clause_constrains_query( array $tax_query_clause, ?string $operator ): bool {
+		$operator = strtoupper( $operator ?? 'IN' );
+
+		if ( in_array( $operator, [ 'EXISTS', 'NOT EXISTS' ], true ) ) {
+			return true;
+		}
+
+		if ( ! array_key_exists( 'terms', $tax_query_clause ) ) {
+			return false;
+		}
+
+		$terms = $tax_query_clause['terms'];
+
+		if ( is_array( $terms ) ) {
+			return [] !== $terms;
+		}
+
+		if ( is_string( $terms ) ) {
+			return '' !== $terms;
+		}
+
+		return null !== $terms && false !== $terms;
+	}
+
+	/**
+	 * Determines whether a tax_query operator excludes matching taxonomy terms.
+	 *
+	 * @param ?string $operator Tax query operator.
+	 */
+	private function tax_query_operator_is_negative( ?string $operator ): bool {
+		if ( null === $operator ) {
+			return false;
+		}
+
+		return in_array( strtoupper( $operator ), [ 'NOT IN', 'NOT EXISTS' ], true );
+	}
+
+	/**
+	 * Determines whether an OR tax_query branch contains a negative clause.
+	 *
+	 * @param array<int|string,mixed> $tax_query         Tax query arguments.
+	 * @param bool                    $is_inside_or_group Whether this query is nested inside an OR relation.
+	 */
+	private function tax_query_has_or_negative_clause( array $tax_query, bool $is_inside_or_group ): bool {
+		$relation = 'AND';
+
+		if ( isset( $tax_query['relation'] ) && is_string( $tax_query['relation'] ) ) {
+			$relation = strtoupper( $tax_query['relation'] );
+		}
+
+		$is_inside_or_group = $is_inside_or_group || ( 'OR' === $relation );
+
+		foreach ( $tax_query as $key => $tax_query_item ) {
+			if ( 'relation' === $key || ! is_array( $tax_query_item ) ) {
+				continue;
+			}
+
+			if ( array_key_exists( 'taxonomy', $tax_query_item ) ) {
+				$operator = null;
+
+				if ( isset( $tax_query_item['operator'] ) && is_string( $tax_query_item['operator'] ) ) {
+					$operator = $tax_query_item['operator'];
+				}
+
+				if ( $is_inside_or_group && $this->tax_query_operator_is_negative( $operator ) ) {
+					return true;
+				}
+
+				continue;
+			}
+
+			if ( $this->tax_query_has_or_negative_clause( $tax_query_item, $is_inside_or_group ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determines whether the taxonomy archive can be treated as belonging to this post type.
+	 *
+	 * @param string $taxonomy Taxonomy name.
+	 */
+	private function taxonomy_only_applies_to_post_type( string $taxonomy ): bool {
+		$taxonomy_object = get_taxonomy( $taxonomy );
+
+		if ( ! ( $taxonomy_object instanceof WP_Taxonomy ) ) {
+			return false;
+		}
+
+		return (
+			in_array( $this->post_type, $taxonomy_object->object_type, true )
+			&&
+			1 === count( $taxonomy_object->object_type )
+		);
 	}
 
 	/**
@@ -539,16 +819,25 @@ class PostType {
 			return [];
 		}
 
+		if ( ! is_string( $orderby['taxonomy'] ) ) {
+			return [];
+		}
+
 		# Taxonomy term ordering courtesy of http://scribu.net/wordpress/sortable-taxonomy-columns.html
-		$clauses['join'] .= "
+		$clauses['join'] .= $wpdb->prepare(
+			"
 			LEFT OUTER JOIN {$wpdb->term_relationships} as ext_cpts_tr
 			ON ( {$wpdb->posts}.ID = ext_cpts_tr.object_id )
 			LEFT OUTER JOIN {$wpdb->term_taxonomy} as ext_cpts_tt
-			ON ( ext_cpts_tr.term_taxonomy_id = ext_cpts_tt.term_taxonomy_id )
+			ON (
+				ext_cpts_tr.term_taxonomy_id = ext_cpts_tt.term_taxonomy_id
+				AND ext_cpts_tt.taxonomy = %s
+			)
 			LEFT OUTER JOIN {$wpdb->terms} as ext_cpts_t
 			ON ( ext_cpts_tt.term_id = ext_cpts_t.term_id )
-		";
-		$clauses['where'] .= $wpdb->prepare( ' AND ( taxonomy = %s OR taxonomy IS NULL )', $orderby['taxonomy'] );
+		",
+			$orderby['taxonomy']
+		);
 		$clauses['groupby'] = 'ext_cpts_tr.object_id';
 		$clauses['orderby'] = 'GROUP_CONCAT( ext_cpts_t.name ORDER BY name ASC ) ';
 		$clauses['orderby'] .= ( isset( $vars['order'] ) && ( 'ASC' === strtoupper( $vars['order'] ) ) ) ? 'ASC' : 'DESC';
@@ -782,7 +1071,9 @@ class PostType {
 		}
 
 		if ( empty( $existing ) ) {
-			$cpt = register_post_type( $this->post_type, $this->args );
+			/** @var lowercase-string&non-empty-string $post_type */
+			$post_type = $this->post_type;
+			$cpt = register_post_type( $post_type, $this->args );
 
 			if ( is_wp_error( $cpt ) ) {
 				trigger_error( esc_html( $cpt->get_error_message() ), E_USER_ERROR );

--- a/src/PostTypeAdmin.php
+++ b/src/PostTypeAdmin.php
@@ -1121,11 +1121,12 @@ ICONCSS;
 			case 'post_date_gmt':
 			case 'post_modified':
 			case 'post_modified_gmt':
-				if ( '0000-00-00 00:00:00' !== get_post_field( $field, $post ) ) {
-					if ( ! isset( $args['date_format'] ) ) {
+				$date = get_post_field( $field, $post );
+				if ( is_string( $date ) && '0000-00-00 00:00:00' !== $date ) {
+					if ( ! isset( $args['date_format'] ) || ! is_string( $args['date_format'] ) ) {
 						$args['date_format'] = get_option( 'date_format' );
 					}
-					echo esc_html( mysql2date( $args['date_format'], get_post_field( $field, $post ) ) );
+					echo esc_html( mysql2date( $args['date_format'], $date ) );
 				}
 				break;
 

--- a/tests/integration/Sites/QueriesTest.php
+++ b/tests/integration/Sites/QueriesTest.php
@@ -143,6 +143,35 @@ class Queries extends Site {
 
 	}
 
+	public function testTaxonomyArchiveSortedByDifferentTaxonomyDoesNotDropPosts(): void {
+
+		$query = $this->get_query( array(
+			'hello_role_filter' => 'crew',
+			'orderby'           => 'test_site_sortables_taxonomy',
+			'order'             => 'ASC',
+		) );
+
+		self::assertEquals( 2, $query->found_posts );
+
+		self::assertSame( 'test_site_sortables_taxonomy', $query->get( 'orderby' ) );
+		self::assertSame( 'ASC',                          $query->get( 'order' ) );
+		self::assertSame( '',                             $query->get( 'meta_key' ) );
+		self::assertSame( '',                             $query->get( 'meta_value' ) );
+		self::assertSame( '',                             $query->get( 'meta_query' ) );
+
+		$post_ids = wp_list_pluck( $query->posts, 'ID' );
+		$expected = array(
+			$this->posts['hello'][1],
+			$this->posts['hello'][2],
+		);
+
+		sort( $post_ids );
+		sort( $expected );
+
+		self::assertEquals( $expected, $post_ids );
+
+	}
+
 	public function testQueryFilteredByPostMetaKey(): void {
 
 		$query = $this->get_query( array(
@@ -332,6 +361,333 @@ class Queries extends Site {
 			$this->posts['person'][1],
 			$this->posts['person'][0],
 		), wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testTaxonomyQueryWithDefaultSortOrder(): void {
+
+		$query = $this->get_query( array(
+			'person_category' => 'team',
+		) );
+
+		self::assertEquals( count( $this->posts['person'] ), $query->found_posts );
+
+		self::assertSame( 'name', $query->get( 'orderby' ) );
+		self::assertSame( 'ASC',  $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+		self::assertEquals( array(
+			$this->posts['person'][1],
+			$this->posts['person'][0],
+		), wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testTaxonomyQueryWithNegativeTaxQueryUsesDefaultSortOrder(): void {
+
+		$query = $this->get_query( array(
+			'person_category' => 'team',
+			'tax_query'       => array(
+				array(
+					'taxonomy' => 'person_role',
+					'field'    => 'slug',
+					'terms'    => array( 'manager' ),
+					'operator' => 'NOT IN',
+				),
+			),
+		) );
+
+		self::assertEquals( count( $this->posts['person'] ), $query->found_posts );
+
+		self::assertSame( 'name', $query->get( 'orderby' ) );
+		self::assertSame( 'ASC',  $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+		self::assertEquals( array(
+			$this->posts['person'][1],
+			$this->posts['person'][0],
+		), wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testTaxonomyQueryWithCustomQueryVarUsesDefaultSortOrder(): void {
+
+		$query = $this->get_query( array(
+			'person_role_filter' => 'crew',
+		) );
+
+		self::assertEquals( count( $this->posts['person'] ), $query->found_posts );
+
+		self::assertSame( 'name', $query->get( 'orderby' ) );
+		self::assertSame( 'ASC',  $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+		self::assertEquals( array(
+			$this->posts['person'][1],
+			$this->posts['person'][0],
+		), wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testTaxonomyNameQueryWithCustomQueryVarNotAffected(): void {
+
+		$query = $this->get_query( array(
+			'person_role' => 'crew',
+		) );
+
+		self::assertEquals( 1, $query->found_posts );
+
+		self::assertSame( '',     $query->get( 'orderby' ) );
+		self::assertSame( 'DESC', $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+		self::assertEquals( $this->posts['post'], wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testTaxonomyQueryWithoutTermNotAffected(): void {
+
+		$query = $this->get_query( array(
+			'taxonomy' => 'person_category',
+		) );
+
+		self::assertEquals( 1, $query->found_posts );
+
+		self::assertSame( '',     $query->get( 'orderby' ) );
+		self::assertSame( 'DESC', $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+		self::assertEquals( $this->posts['post'], wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testZeroTaxonomyQueryVarNotAffected(): void {
+
+		$query = $this->get_query( array(
+			'person_category' => '0',
+		) );
+
+		self::assertEquals( 1, $query->found_posts );
+
+		self::assertSame( '',     $query->get( 'orderby' ) );
+		self::assertSame( 'DESC', $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+		self::assertEquals( $this->posts['post'], wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testSharedTaxonomyQueryWithDefaultSortOrderNotAffected(): void {
+
+		register_taxonomy_for_object_type( 'person_category', 'hello' );
+		wp_add_object_terms( $this->posts['hello'][0], 'Team', 'person_category' );
+
+		$query = $this->get_query( array(
+			'person_category' => 'team',
+		) );
+
+		self::assertEquals( 3, $query->found_posts );
+
+		self::assertSame( '',     $query->get( 'orderby' ) );
+		self::assertSame( 'DESC', $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+		self::assertEquals( array(
+			$this->posts['hello'][0],
+			$this->posts['person'][0],
+			$this->posts['person'][1],
+		), wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testMixedTaxonomyQueryWithDefaultSortOrderNotAffected(): void {
+
+		$query = $this->get_query( array(
+			'tax_query' => array(
+				'relation' => 'OR',
+				array(
+					'taxonomy' => 'person_category',
+					'field'    => 'slug',
+					'terms'    => array( 'team' ),
+				),
+				array(
+					'taxonomy' => 'hello_category',
+					'field'    => 'slug',
+					'terms'    => array( 'beta' ),
+				),
+			),
+		) );
+
+		self::assertEquals( 3, $query->found_posts );
+
+		self::assertSame( '',     $query->get( 'orderby' ) );
+		self::assertSame( 'DESC', $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+		self::assertEquals( array(
+			$this->posts['hello'][0],
+			$this->posts['person'][0],
+			$this->posts['person'][1],
+		), wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testTaxonomyQueryVarWithMixedTaxQueryNotAffected(): void {
+
+		$query = $this->get_query( array(
+			'person_category' => 'team',
+			'tax_query'       => array(
+				'relation' => 'OR',
+				array(
+					'taxonomy' => 'hello_category',
+					'field'    => 'slug',
+					'terms'    => array( 'beta' ),
+				),
+			),
+		) );
+
+		self::assertEquals( 3, $query->found_posts );
+
+		self::assertSame( '',     $query->get( 'orderby' ) );
+		self::assertSame( 'DESC', $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+		self::assertEquals( array(
+			$this->posts['hello'][0],
+			$this->posts['person'][0],
+			$this->posts['person'][1],
+		), wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testNegativeTaxonomyQueryWithDefaultSortOrderNotAffected(): void {
+
+		$query = $this->get_query( array(
+			'tax_query' => array(
+				array(
+					'taxonomy' => 'person_category',
+					'field'    => 'slug',
+					'terms'    => array( 'team' ),
+					'operator' => 'NOT IN',
+				),
+			),
+		) );
+
+		self::assertEquals( 1, $query->found_posts );
+
+		self::assertSame( '',     $query->get( 'orderby' ) );
+		self::assertSame( 'DESC', $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+		self::assertEquals( $this->posts['post'], wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testEmptyAndTaxonomyQueryWithDefaultSortOrderNotAffected(): void {
+
+		$query = $this->get_query( array(
+			'tax_query' => array(
+				array(
+					'taxonomy' => 'person_category',
+					'field'    => 'slug',
+					'terms'    => array(),
+					'operator' => 'AND',
+				),
+			),
+		) );
+
+		self::assertGreaterThan( count( $this->posts['person'] ), $query->found_posts );
+
+		self::assertSame( '',     $query->get( 'orderby' ) );
+		self::assertSame( 'DESC', $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+	}
+
+	public function testOrNegativeTaxonomyQueryWithDefaultSortOrderNotAffected(): void {
+
+		$query = $this->get_query( array(
+			'tax_query' => array(
+				'relation' => 'OR',
+				array(
+					'taxonomy' => 'person_role',
+					'field'    => 'slug',
+					'terms'    => array( 'crew' ),
+				),
+				array(
+					'taxonomy' => 'person_role',
+					'field'    => 'slug',
+					'terms'    => array( 'crew' ),
+					'operator' => 'NOT IN',
+				),
+			),
+		) );
+
+		self::assertEquals( count( $this->posts['person'] ), $query->found_posts );
+
+		self::assertSame( '',     $query->get( 'orderby' ) );
+		self::assertSame( 'DESC', $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
+
+		self::assertEquals( array(
+			$this->posts['person'][0],
+			$this->posts['person'][1],
+		), wp_list_pluck( $query->posts, 'ID' ) );
+
+	}
+
+	public function testNestedOrNegativeTaxonomyQueryWithDefaultSortOrderNotAffected(): void {
+
+		$query = $this->get_query( array(
+			'tax_query' => array(
+				'relation' => 'OR',
+				array(
+					array(
+						'taxonomy' => 'person_role',
+						'field'    => 'slug',
+						'terms'    => array( 'crew' ),
+						'operator' => 'NOT IN',
+					),
+				),
+				array(
+					'taxonomy' => 'person_category',
+					'field'    => 'slug',
+					'terms'    => array( 'team' ),
+				),
+			),
+		) );
+
+		self::assertGreaterThan( count( $this->posts['person'] ), $query->found_posts );
+
+		self::assertSame( '',     $query->get( 'orderby' ) );
+		self::assertSame( 'DESC', $query->get( 'order' ) );
+		self::assertSame( '',     $query->get( 'meta_key' ) );
+		self::assertSame( '',     $query->get( 'meta_value' ) );
+		self::assertSame( '',     $query->get( 'meta_query' ) );
 
 	}
 

--- a/tests/integration/Test.php
+++ b/tests/integration/Test.php
@@ -104,10 +104,13 @@ abstract class Test extends \Codeception\TestCase\WPTestCase {
 		);
 		$hello->query_var = 'hi';
 
-		$this->args['hello'] = $hello;
+			$this->args['hello'] = $hello;
 
-		$this->cpts['hello'] = register_extended_post_type( 'hello', $hello->toArray() );
-		$this->cpts['hello']->add_taxonomy( 'hello_category' );
+			$this->cpts['hello'] = register_extended_post_type( 'hello', $hello->toArray() );
+			$this->cpts['hello']->add_taxonomy( 'hello_category' );
+			$this->cpts['hello']->add_taxonomy( 'hello_role', array(
+				'query_var' => 'hello_role_filter',
+			) );
 
 		$person = new \ExtCPTs\Args\PostType;
 
@@ -140,11 +143,14 @@ abstract class Test extends \Codeception\TestCase\WPTestCase {
 
 		$this->cpts['person'] = register_extended_post_type( 'person', $person->toArray(), array(
 			'plural' => 'People',
-		) );
-		$this->cpts['person']->add_taxonomy( 'person_category' );
-		$this->cpts['nice-thing'] = register_extended_post_type( 'nice-thing', array(), array(
-			'slug' => 'Things',
-		) );
+			) );
+			$this->cpts['person']->add_taxonomy( 'person_category' );
+			$this->cpts['person']->add_taxonomy( 'person_role', array(
+				'query_var' => 'person_role_filter',
+			) );
+			$this->cpts['nice-thing'] = register_extended_post_type( 'nice-thing', array(), array(
+				'slug' => 'Things',
+			) );
 		$this->cpts['foo'] = register_extended_post_type( 'foo', array(
 			'rewrite' => array(
 				'permastruct' => 'foo/%author%/%foo_category%/%foo%',
@@ -202,10 +208,15 @@ abstract class Test extends \Codeception\TestCase\WPTestCase {
 
 		$wp_rewrite->flush_rules();
 
-		foreach ( array( '0', 'Alpha', 'Beta', 'Gamma', 'Delta' ) as $slug ) {
-			wp_insert_term( $slug, 'hello_category' );
-			wp_insert_term( $slug, 'foo_category' );
-		}
+			foreach ( array( '0', 'Alpha', 'Beta', 'Gamma', 'Delta' ) as $slug ) {
+				wp_insert_term( $slug, 'hello_category' );
+				wp_insert_term( $slug, 'foo_category' );
+				}
+				wp_insert_term( 'Crew', 'hello_role' );
+				wp_insert_term( '0', 'person_category' );
+				wp_insert_term( 'Team', 'person_category' );
+				wp_insert_term( 'Crew', 'person_role' );
+				wp_insert_term( 'Manager', 'person_role' );
 
 		// Post
 		$this->posts['post'][] = self::factory()->post->create( array(
@@ -230,18 +241,20 @@ abstract class Test extends \Codeception\TestCase\WPTestCase {
 			'post_type' => 'hello',
 			'post_name' => 'Delta',
 			'post_date' => '1984-02-25 00:03:00'
-		) );
-		add_post_meta( $this->posts['hello'][1], 'test_meta_key', '0' );
+			) );
+			add_post_meta( $this->posts['hello'][1], 'test_meta_key', '0' );
+			wp_add_object_terms( $this->posts['hello'][1], 'Crew', 'hello_role' );
 
-		// Hello 2
-		$this->posts['hello'][2] = self::factory()->post->create( array(
+			// Hello 2
+			$this->posts['hello'][2] = self::factory()->post->create( array(
 			'guid'      => 'guid',
 			'post_type' => 'hello',
 			'post_name' => 'Beta',
 			'post_date' => '1984-02-25 00:02:00'
-		) );
-		add_post_meta( $this->posts['hello'][2], 'test_meta_key', 'Beta' );
-		wp_add_object_terms( $this->posts['hello'][2], 'Alpha', 'hello_category' );
+			) );
+			add_post_meta( $this->posts['hello'][2], 'test_meta_key', 'Beta' );
+			wp_add_object_terms( $this->posts['hello'][2], 'Alpha', 'hello_category' );
+			wp_add_object_terms( $this->posts['hello'][2], 'Crew', 'hello_role' );
 
 		// Hello 3
 		$this->posts['hello'][3] = self::factory()->post->create( array(
@@ -256,15 +269,21 @@ abstract class Test extends \Codeception\TestCase\WPTestCase {
 			'guid'      => 'guid',
 			'post_type' => 'person',
 			'post_name' => 'Beta',
-			'post_date' => '1984-02-25 00:01:00'
-		) );
-		$this->posts['person'][1] = self::factory()->post->create( array(
-			'guid'      => 'guid',
+			'post_date' => '1984-02-25 00:02:00'
+				) );
+				wp_add_object_terms( $this->posts['person'][0], 'Team', 'person_category' );
+				wp_add_object_terms( $this->posts['person'][0], '0', 'person_category' );
+				wp_add_object_terms( $this->posts['person'][0], 'Crew', 'person_role' );
+
+			$this->posts['person'][1] = self::factory()->post->create( array(
+				'guid'      => 'guid',
 			'post_type' => 'person',
 			'post_name' => 'Alpha',
-			'post_date' => '1984-02-25 00:02:00'
-		) );
-		$this->posts['nice-thing'][0] = self::factory()->post->create( array(
+			'post_date' => '1984-02-25 00:01:00'
+			) );
+			wp_add_object_terms( $this->posts['person'][1], 'Team', 'person_category' );
+			wp_add_object_terms( $this->posts['person'][1], 'Crew', 'person_role' );
+			$this->posts['nice-thing'][0] = self::factory()->post->create( array(
 			'guid'      => 'guid',
 			'post_type' => 'nice-thing',
 		) );


### PR DESCRIPTION
Closes #207.

## Summary

This updates front-end site sortables so a taxonomy archive can receive the default `site_sortables` ordering when the query is provably constrained to the custom post type.

- Apply default `site_sortables` to CPT taxonomy archive queries whose taxonomy constraints are exclusive to that CPT.
- Honor registered taxonomy query vars, custom taxonomy query vars, legacy `taxonomy` plus `term`, and explicit `tax_query` constraints.
- Combine the archive taxonomy constraint with any explicit `tax_query` before deciding whether the query only applies to the CPT.
- Avoid applying CPT sorting to shared taxonomies, mixed taxonomy queries, negative-only clauses, OR branches with negative clauses, nested OR negative clauses, and empty/unconstrained clauses.
- Keep taxonomy term sorting from dropping posts that lack a term in the sort taxonomy by moving the taxonomy match into the join condition.
- Include small PHPStan type cleanups in `PostType` and `PostTypeAdmin`.

## Validation

- `composer validate --strict --no-check-lock`
- PHP syntax checks for the touched files
- PHPCS on `src/PostType.php`, `src/PostTypeAdmin.php`, `tests/integration/Test.php`, and `tests/integration/Sites/QueriesTest.php`
- `php -d register_argc_argv=On vendor/bin/codecept build`
- `php -d register_argc_argv=On vendor/bin/phpstan analyze -v --memory-limit=1024M`
- `vendor/bin/integration-tests 'tests/integration/Sites/QueriesTest.php'`
  - singlesite: 29 tests, 189 assertions
  - multisite: 29 tests, 189 assertions
- `vendor/bin/integration-tests`
  - singlesite: 63 tests, 394 assertions
  - multisite: 63 tests, 394 assertions
- `git diff --check`